### PR TITLE
Optimize maxCellsize to be dependant on the dimension of the grid.

### DIFF
--- a/src/t8_vtk/t8_vtk_writer.hxx
+++ b/src/t8_vtk/t8_vtk_writer.hxx
@@ -364,9 +364,10 @@ class vtk_writer {
     T8_ASSERT (cellTypes != NULL);
 
     /* Allocate VTK Memory for the arrays */
-    int iMaxCellSize = 20;
-    cellArray->AllocateEstimate (num_cells, iMaxCellSize);
-    points_store->Allocate (num_cells * iMaxCellSize);
+    const int grid_dim = grid_get_dim (grid);
+    const int maximum_cell_size = curved_flag ? t8_curved_dim_max_nodes[grid_dim] : t8_dim_max_nodes[grid_dim];
+    cellArray->AllocateEstimate (num_cells, maximum_cell_size);
+    points_store->Allocate (num_cells * maximum_cell_size);
     points->InitPointInsertion (points_store, unstructuredGrid->GetBounds ());
     vtk_treeid->Allocate (num_cells);
     vtk_mpirank->Allocate (num_cells);

--- a/src/t8_vtk/t8_vtk_writer_helper.cxx
+++ b/src/t8_vtk/t8_vtk_writer_helper.cxx
@@ -209,3 +209,17 @@ grid_element_level<t8_cmesh_t> ([[maybe_unused]] const t8_cmesh_t grid, [[maybe_
 {
   return 0;
 }
+
+template <>
+int
+grid_get_dim<t8_forest_t> (const t8_forest_t grid)
+{
+  return t8_forest_get_dimension (grid);
+}
+
+template <>
+int
+grid_get_dim<t8_cmesh_t> (const t8_cmesh_t grid)
+{
+  return t8_cmesh_get_dimension (grid);
+}

--- a/src/t8_vtk/t8_vtk_writer_helper.hxx
+++ b/src/t8_vtk/t8_vtk_writer_helper.hxx
@@ -29,6 +29,10 @@
 #define T8_FOREST_VTK_QUADRATIC_ELEMENT_MAX_CORNERS 20
 /** Lookup table for number of nodes for curved eclasses. */
 const int t8_curved_eclass_num_nodes[T8_ECLASS_COUNT] = { 1, 3, 8, 6, 20, 10, 15, 13 };
+/** Lookup table for maximal number of vtk nodes for curved eclasses per dimension */
+const int t8_curved_dim_max_nodes[4] = { 1, 3, 8, 20 };
+/** Lookup table for maximal number of vtk nodes for linear eclasses per dimension */
+const int t8_dim_max_nodes[4] = { 1, 2, 4, 8 };
 
 #if T8_ENABLE_VTK
 /** Lookup table for vtk types of curved elements */
@@ -224,5 +228,16 @@ grid_element_to_coords (const grid_t grid, const t8_locidx_t itree, const t8_ele
 template <typename grid_t>
 int
 grid_element_level (const grid_t grid, const t8_locidx_t itree, const t8_element_t *element);
+
+/**
+ * Get the dimension of the grid. 
+ * 
+ * \tparam grid_t 
+ * \param[in] grid A forest/cmesh.
+ * \return The dimension of the grid.
+ */
+template <typename grid_t>
+int
+grid_get_dim (const grid_t grid);
 
 #endif /* T8_VTK_WRITER_HELPER */


### PR DESCRIPTION
Minor changes to the cellsize. 
That way not allways 20 entities are allocated per cell, which is only necessary for 3D and curved meshes. Instead we compute the maximum cell size based on the dimension. 


**_All these boxes must be checked by the AUTHOR before requesting review:_**
- [ ] The PR is *small enough* to be reviewed easily. If not, consider splitting up the changes in multiple PRs.
- [ ] The title starts with one of the following prefixes: `Documentation:`, `Bugfix:`, `Feature:`, `Improvement:` or `Other:`.
- [ ] If the PR is related to an issue, make sure to link it.
- [ ] The author made sure that, as a reviewer, he/she would check all boxes below.

**_All these boxes must be checked by the REVIEWERS before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is *fully understood, bug free, well-documented and well-structured*.
#### General
- [ ] The reviewer executed the new code features at least once and checked the results manually.
- [ ] The code follows the [t8code coding guidelines](https://github.com/DLR-AMR/t8code/wiki/Coding-Guideline).
- [ ] New source/header files are properly added to the CMake files.
- [ ] The code is well documented. In particular, all function declarations, structs/classes and their members have a proper doxygen documentation.
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue).
#### Tests
- [ ] The code is covered in an existing or new test case using Google Test.
- [ ] Valgrind doesn't find any bugs in the new code. [This script](https://github.com/DLR-AMR/t8code/blob/main/scripts/check_valgrind.sh) can be used to check for errors; see also this [wiki article](https://github.com/DLR-AMR/t8code/wiki/Debugging-with-valgrind).

If the Pull request introduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually).
#### Scripts and Wiki
- [ ] If a new directory with source files is added, it must be covered by the `script/find_all_source_files.scp` to check the indentation of these files.
- [ ] If this PR introduces a new feature, it must be covered in an example or tutorial and a Wiki article.
#### License
- [ ] The author added a BSD statement to `doc/` (or already has one).